### PR TITLE
Filter domains

### DIFF
--- a/oidc/constants.py
+++ b/oidc/constants.py
@@ -11,6 +11,11 @@ WELL_KNOWN_SCHEME = "/.well-known/openid-configuration"
 ERR_INVALID_RESPONSE = (
     "Unable to fetch user information from provider.  Please check the log."
 )
+ERR_INVALID_DOMAIN = (
+    "The domain for your account (%s) is not allowed to authenticate with this provider."
+)
+OIDC_DOMAIN_BLOCKLIST = frozenset(getattr(settings, "OIDC_DOMAIN_BLOCKLIST", []))
+OIDC_DOMAIN_ALLOWLIST = frozenset(getattr(settings, "OIDC_DOMAIN_ALLOWLIST", []))
 ISSUER = None
 
 DATA_VERSION = "1"

--- a/oidc/views.py
+++ b/oidc/views.py
@@ -55,7 +55,7 @@ class FetchUser(AuthView):
         if domain in OIDC_DOMAIN_BLOCKLIST:
             return helper.error(ERR_INVALID_DOMAIN % (domain,))
 
-        if OIDC_DOMAIN_ALLOWLIST != set() and domain not in OIDC_DOMAIN_ALLOWLIST:
+        if OIDC_DOMAIN_ALLOWLIST and domain not in OIDC_DOMAIN_ALLOWLIST:
             return helper.error(ERR_INVALID_DOMAIN % (domain,))
 
         helper.bind_state("domain", domain)

--- a/oidc/views.py
+++ b/oidc/views.py
@@ -5,8 +5,9 @@ from sentry.utils import json
 from sentry.utils.compat import map
 from sentry.utils.signing import urlsafe_b64decode
 
-from .constants import ERR_INVALID_RESPONSE, ISSUER, ERR_INVALID_DOMAIN
-
+from .constants import (
+    ERR_INVALID_RESPONSE, ISSUER, ERR_INVALID_DOMAIN, OIDC_DOMAIN_ALLOWLIST, OIDC_DOMAIN_BLOCKLIST,
+)
 logger = logging.getLogger("sentry.auth.oidc")
 
 

--- a/oidc/views.py
+++ b/oidc/views.py
@@ -43,10 +43,11 @@ class FetchUser(AuthView):
             return helper.error(ERR_INVALID_RESPONSE)
 
         # support legacy style domains with pure domain regexp
+        user_domain = extract_domain(payload["email"])
         if self.version is None:
-            domain = extract_domain(payload["email"])
+            domain = user_domain
         else:
-            domain = payload.get("hd", extract_domain(payload["email"]))
+            domain = payload.get("hd", user_domain)
 
         if domain is None:
             return helper.error(ERR_INVALID_DOMAIN % (domain,))

--- a/oidc/views.py
+++ b/oidc/views.py
@@ -46,7 +46,7 @@ class FetchUser(AuthView):
         if self.version is None:
             domain = extract_domain(payload["email"])
         else:
-            domain = payload.get("hd")
+            domain = payload.get("hd", extract_domain(payload["email"]))
 
         if domain is None:
             return helper.error(ERR_INVALID_DOMAIN % (domain,))

--- a/oidc/views.py
+++ b/oidc/views.py
@@ -5,7 +5,7 @@ from sentry.utils import json
 from sentry.utils.compat import map
 from sentry.utils.signing import urlsafe_b64decode
 
-from .constants import ERR_INVALID_RESPONSE, ISSUER
+from .constants import ERR_INVALID_RESPONSE, ISSUER, ERR_INVALID_DOMAIN
 
 logger = logging.getLogger("sentry.auth.oidc")
 
@@ -46,6 +46,15 @@ class FetchUser(AuthView):
             domain = extract_domain(payload["email"])
         else:
             domain = payload.get("hd")
+
+        if domain is None:
+            return helper.error(ERR_INVALID_DOMAIN % (domain,))
+
+        if domain in OIDC_DOMAIN_BLOCKLIST:
+            return helper.error(ERR_INVALID_DOMAIN % (domain,))
+
+        if OIDC_DOMAIN_ALLOWLIST != set() and domain not in OIDC_DOMAIN_ALLOWLIST:
+            return helper.error(ERR_INVALID_DOMAIN % (domain,))
 
         helper.bind_state("domain", domain)
         helper.bind_state("user", payload)


### PR DESCRIPTION
This introduces 2 variables
OIDC_DOMAIN_BLOCKLIST
OIDC_DOMAIN_ALLOWLIST
to filter out which email domains are allowed to login when using SSO.
Related issue
https://github.com/siemens/sentry-auth-oidc/issues/27
It is possible to do away entirely with these new variables if equivalent setting for domains can be found. However, this seems not to be available.
https://github.com/getsentry/self-hosted/issues/2894